### PR TITLE
Update build_network_zh.md

### DIFF
--- a/docs/build_network_zh.md
+++ b/docs/build_network_zh.md
@@ -320,7 +320,7 @@ CORE_PEER_TLS_ROOTCERT_FILE=/opt/gopath/src/github.com/hyperledger/fabric/peer/c
 
 我们将使用`docker exec`命令进入CLI容器：
 ```bash
-docker exec -it bash
+docker exec -it cli bash
 ```
 
 如果成功，你将看到下列信息：


### PR DESCRIPTION
修复一个命令错误，原文中“docker exec -it bash”命令错误，修改为“docker exec -it cli bash”