### PR TITLE
Chain code dev port issue. 7051 to 7052

### DIFF
--- a/docs/chaincode_developers_zh.md
+++ b/docs/chaincode_developers_zh.md
@@ -451,7 +451,7 @@ go build
 现在运行chaincode：
 
 ```bash
-CORE_PEER_ADDRESS=peer:7051 CORE_CHAINCODE_ID_NAME=mycc:0 ./sacc
+CORE_PEER_ADDRESS=peer:7052 CORE_CHAINCODE_ID_NAME=mycc:0 ./sacc
 ```
 
 The chaincode is started with peer and chaincode logs indicating successful registration with the peer. Note that at this stage the chaincode is not associated with any channel. This is done in subsequent steps using the `instantiate` command.


### PR DESCRIPTION
https://jira.hyperledger.org/browse/FAB-6349 Please check this ticket… When we use dev mode. 7051 port for start sacc will throw Error starting SimpleAsset chaincode: error sending chaincode REGISTER: EOF